### PR TITLE
* Define system wide screen lock key code for mac os (10.13 and later)

### DIFF
--- a/keyboards/ergodox_ez/keymaps/sai2791/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/sai2791/keymap.c
@@ -5,6 +5,8 @@
 #include "keymap_german.h"
 #include "keymap_nordic.h"
 
+#define KC_LOCKSCR  LCTL(LGUI(KC_Q)) // mac system wide Lock Screen 10.13 and later
+
 enum custom_keycodes {
   PLACEHOLDER = SAFE_RANGE, // can always be here
   EPRM,
@@ -63,7 +65,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
  * |        |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |   4  |   5  |   6  |   +  |        |
  * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
- * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   \  |        |
+ * |        |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   \  | LockScr|
  * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
  *   |      |      |      |      |      |                                       |      |    . |   0  |   =  |      |
  *   `----------------------------------'                                       `----------------------------------'
@@ -89,7 +91,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                            KC_TRANSPARENT,KC_F6,KC_F7,KC_F8,KC_F9,KC_F10,KC_F11,
                                            KC_TRANSPARENT,KC_UP,KC_7,KC_8,KC_9,KC_ASTR,KC_F12,
                                            KC_DOWN,KC_4,KC_5,KC_6,KC_TRANSPARENT,KC_TRANSPARENT,
-                                           KC_TRANSPARENT,KC_AMPR,KC_1,KC_2,KC_3,KC_BSLASH,KC_TRANSPARENT,
+                                           KC_TRANSPARENT,KC_AMPR,KC_1,KC_2,KC_3,KC_BSLASH,KC_LOCKSCR,
                                            KC_TRANSPARENT,KC_DOT,KC_0,KC_EQUAL,KC_TRANSPARENT,
                                                                                 RGB_TOG,RGB_SLD,
                                                                                 KC_TRANSPARENT,


### PR DESCRIPTION
* Added new keycode KC_LOCKSCR to symbols layer to lock the machine from the Ergodox

## Description
Created a new defined keymap KC_LOCKSCR for the system wide lock command on mac os 
(10.3 and later). 

Added the keymap to the symbol layer on my personal Ergodox keymap

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
