### PR TITLE
Attempting to get numlock working for ymdk_np21 numpad

### DIFF
--- a/keyboards/ymdk_np21/keymaps/sai2791/keymap.c
+++ b/keyboards/ymdk_np21/keymaps/sai2791/keymap.c
@@ -1,4 +1,5 @@
 #include QMK_KEYBOARD_H
+#include "keymap.h"
 
 #define _NP 0
 #define _BL  1
@@ -89,6 +90,8 @@ uint32_t layer_state_set_user(uint32_t state) {
     switch (biton32(state)) {
     case _NP:
         backlight_set(0);
+        DDRD  |= NUMLOCK_PORT;
+        PORTD |= NUMLOCK_PORT;
         break;
     case _BL:
         backlight_set(20);
@@ -102,4 +105,32 @@ uint32_t layer_state_set_user(uint32_t state) {
         break;
     }
   return state;
+}
+
+void led_set_user(uint8_t usb_led) {
+  if (usb_led & (1 << USB_LED_NUM_LOCK)) {
+    // turn on
+    DDRD  |= NUMLOCK_PORT;
+    PORTD |= NUMLOCK_PORT;
+  } else {
+    // turn off
+    DDRD  &= ~NUMLOCK_PORT;
+    PORTD &= ~NUMLOCK_PORT;
+  }
+
+  if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
+    DDRD  |= CAPSLOCK_PORT;
+    PORTD |= CAPSLOCK_PORT;
+  } else {
+    DDRD  &= ~CAPSLOCK_PORT;
+    PORTD &= ~CAPSLOCK_PORT;
+  }
+
+  if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
+    DDRD  |= SCROLLLOCK_PORT;
+    PORTD |= SCROLLLOCK_PORT;
+  } else {
+    DDRD  &= ~SCROLLLOCK_PORT;
+    PORTD &= ~SCROLLLOCK_PORT;
+  }
 }

--- a/keyboards/ymdk_np21/keymaps/sai2791/keymap.c
+++ b/keyboards/ymdk_np21/keymaps/sai2791/keymap.c
@@ -41,7 +41,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_KP_0,     KC_KP_1,     KC_KP_4,    KC_KP_7,    KC_NLCK,     KC_ESC,    \
   KC_NO,       KC_KP_2,     KC_KP_5,    KC_KP_8,    KC_KP_SLASH,    KC_TAB,    \
   KC_KP_DOT,   KC_KP_3,     KC_KP_6,    KC_KP_9,    KC_KP_ASTERISK, KC_BSPACE, \
-  KC_KP_ENTER, KC_KP_ENTER, KC_KP_PLUS, KC_PLUS,    KC_KP_MINUS,    TO(_BL)    \
+  KC_NO, KC_KP_ENTER, KC_NO, KC_KP_PLUS,    KC_KP_MINUS,    TO(_BL)    \
 ),
 /* Backlight
  * ,----------------------------------------------------.

--- a/keyboards/ymdk_np21/keymaps/sai2791/keymap.c
+++ b/keyboards/ymdk_np21/keymaps/sai2791/keymap.c
@@ -38,7 +38,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 
 [_NP] = LAYOUT_numpad_6x4( \
-  KC_KP_0,     KC_KP_1,     KC_KP_4,    KC_KP_7,    KC_NUMLOCK,     KC_ESC,    \
+  KC_KP_0,     KC_KP_1,     KC_KP_4,    KC_KP_7,    KC_NLCK,     KC_ESC,    \
   KC_NO,       KC_KP_2,     KC_KP_5,    KC_KP_8,    KC_KP_SLASH,    KC_TAB,    \
   KC_KP_DOT,   KC_KP_3,     KC_KP_6,    KC_KP_9,    KC_KP_ASTERISK, KC_BSPACE, \
   KC_KP_ENTER, KC_KP_ENTER, KC_KP_PLUS, KC_PLUS,    KC_KP_MINUS,    TO(_BL)    \
@@ -56,9 +56,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [_BL] = LAYOUT_numpad_6x4( \
   BL_BRTG, _______, _______, _______, _______, KC_NO,   \
-  _______, BL_OFF,  BL_TOGG, BL_ON,   _______, TO(_MP), \
+  KC_NO, BL_OFF,  BL_TOGG, BL_ON,   _______, TO(_MP), \
   _______, _______, _______, _______, _______, KC_NO,   \
-  BL_DEC,  BL_DEC,  BL_INC,  BL_INC,  _______, KC_NO    \
+  KC_NO,  BL_DEC,  KC_NO,  BL_INC,  _______, KC_NO    \
 ),
 /* Macropad
  * ,----------------------------------------------------.

--- a/keyboards/ymdk_np21/keymaps/sai2791/keymap.h
+++ b/keyboards/ymdk_np21/keymaps/sai2791/keymap.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define NUMLOCK_PORT    (1 << 0)  // D0
+#define CAPSLOCK_PORT   (1 << 1)  // D1
+#define BACKLIGHT_PORT  (1 << 4)  // D4
+#define SCROLLLOCK_PORT (1 << 6)  // D6


### PR DESCRIPTION
Trying to get the numlock led light working on the numpad

## Description
Changed 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
