### PR TITLE
Implement gui tab (MAC) snippet found on reddit notes in userspace

### DIFF
--- a/keyboards/ergodox_ez/keymaps/sai2791/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/sai2791/keymap.c
@@ -79,7 +79,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                            KC_TRANSPARENT,KC_EXLM,KC_AT,KC_LCBR,KC_RCBR,KC_PIPE,KC_TRANSPARENT,
                                            KC_TRANSPARENT,KC_HASH,KC_DLR,KC_LPRN,KC_RPRN,KC_GRAVE,
                                            KC_TRANSPARENT,KC_PERC,KC_CIRC,KC_LBRACKET,KC_RBRACKET,KC_TILD,KC_TRANSPARENT,
-                                           KC_TRANSPARENT,KC_TRANSPARENT,KC_TRANSPARENT,DESK_L,DESK_R,
+                                           KC_TRANSPARENT,GUI_TAB,KC_TRANSPARENT,DESK_L,DESK_R,
                                                                                 RGB_MOD,KC_TRANSPARENT,
                                                                                 KC_TRANSPARENT,
                                                                                 RGB_VAD,RGB_VAI,KC_TRANSPARENT,
@@ -277,7 +277,32 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  // persistant variable
+  static bool in_tab = false; // does an GUI-TAB, for windows cycling, without an alt key
+
+  if (keycode != GUI_TAB && in_tab)
+  {
+    // Exit alt tab before treating normally the keycode
+    SEND_STRING(SS_UP(X_LGUI));
+    in_tab = false;
+  }
+
   switch (keycode) {
+      case GUI_TAB:
+        // Macro to handle lower-tab as alt-tab
+        if (record->event.pressed) {
+          if (!in_tab)
+          {
+            SEND_STRING(SS_DOWN(X_LGUI) SS_TAP(X_TAB));
+            in_tab = true;
+          } else {
+            SEND_STRING(SS_TAP(X_TAB));
+            // Do not release Alt here, or it will be impossible to switch more than one window:
+            // alt-tab-tab will be interpreted as alt-tab, then tab
+          }
+        }
+        return false;
+
     // dynamically generate these.
     case EPRM:
       if (record->event.pressed) {

--- a/users/sai2791/config.h
+++ b/users/sai2791/config.h
@@ -10,6 +10,7 @@
 // taken from a commit by lbussell (#4996) QMK github respository
 #define DESK_L LCTL(KC_LEFT)
 #define DESK_R LCTL(KC_RGHT)
+#define GUI_TAB LGUI(KC_TAB)
 
 // Disable action_get_macro and fn_actions, since we don't use these
 // and it saves on space in the firmware.

--- a/users/sai2791/readme.md
+++ b/users/sai2791/readme.md
@@ -17,6 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 This is my personal userspace.
 
+24/02/2019
+Implement on key task switching (Alt-tab in the windows world) Using gui_tab
+
 30/1/2019
 - New kemaps added desk_l and desk_r, should add these to my keymaps
 - maybe move the window moving, and screen moving stuff to a layer
@@ -25,6 +28,7 @@ This is my personal userspace.
 - System wide Mac lock screen Keys (KC_LOCKSCR)
 - System wide Mac Desktop Left key (DESK_L)
 - System wide Mac Desktop Right Key (DESK_R)
+- System wide GUI TAB key (GUI_TAB)
 
 # Shared Keyboards
 - ergodox_ez  Doesnt use the sai2791.c
@@ -36,3 +40,4 @@ This is my personal userspace.
 - fn_action removed
 - Desk_L and Desk_R are not working on the keyboard needs to be investigated, the lock
 screen seems to be working fine.  Checking the code it appears that the define is not in the dev branch
+gui tab stuff mostly taken from https://www.reddit.com/r/olkb/comments/9ncbhu/brainstorming_for_a_onekey_alttab_function_what/


### PR DESCRIPTION
Added functionality for a single key to perform the gui-tab alt switching

## Description
Implement a change to allow gui_tab to work as if the user was continuing to hold gui, so that gui_tab does not just tab to the last opened application, and the user can step through the open applications as expected.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
